### PR TITLE
fix(kopiur): lower B2 epoch minDuration to unblock index compaction

### DIFF
--- a/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository.yaml
@@ -22,5 +22,11 @@ spec:
       name: kopiur-repository-secret
       namespace: kopiur-system
       key: KOPIA_PASSWORD
+  parameters:
+    epoch:
+      # kopia's 24h default let epochs hold ~2600 index blobs at this cluster's
+      # write rate; compaction trails two epochs, so the repo carried ~5k
+      # uncompacted blobs and `repository connect` took over 4 minutes.
+      minDuration: 4h
   scheduleDefaults:
     timezone: America/Los_Angeles


### PR DESCRIPTION
## Problem

`ClusterRepository/b2` has had `IndexBlobHealth: False (TooManyIndexBlobs)` since 2026-08-14, with the count climbing 3508 → 4881. Two separate causes:

**1. Maintenance was gated off for 11 days (already resolved).** No `kopia maintenance` ran between 2026-08-18 19:08 UTC and 2026-08-29 01:44 UTC. This was upstream kopiur [#413](https://github.com/home-operations/kopiur/issues/413): a slow cold-cache `repository connect` blew the bootstrap deadline, was misclassified as `BackendUnreachable`, opened the circuit breaker, and the maintenance gate then deferred maintenance because the repo was Degraded — even though maintenance is the cure. Chart `0.10.5` (deployed 2026-08-29T01:38Z) fixed the gate; maintenance resumed six minutes later and every quick/full slot since has succeeded.

**2. The 24h epoch floor — what this PR fixes.** The manifest declared no `spec.parameters.epoch`, leaving kopia at its `MinEpochDuration` default of 24h.

## Why the backlog persists without this change

kopia cannot compact an epoch until it is older than `minDuration`, and compaction trails two epochs behind. Measured from `kopia index epoch list`:

```
Current Epoch: 4
4  2026-08-29 02:15 ... 2026-08-30 01:16   2588 blobs   span 23h
3  2026-08-18 02:42 ... 2026-08-29 01:44   2290 blobs   span 263h   <- the stall
2:  single-epoch 1 blob   (compacted)
1:  single-epoch 1 blob   (compacted)
0:  single-epoch 1 blob   (compacted)
```

At the measured write rate of ~112 index blobs/hour, steady state is `2 × minDuration × rate`:

| `minDuration` | Steady-state blobs | vs. 1000 default threshold |
| --- | --- | --- |
| 24h (before) | ~5400 | matches observed 4881 |
| 6h | ~1350 | still trips it |
| **4h (this PR)** | **~900** | clears |
| 3h | ~670 | clears comfortably |

## Impact

The 4881-blob backlog pushed `kopia repository connect` to **4m13s** (measured). That is why the `b2-discovery` health probe kept hitting `ProbeDeadlineExceeded` and reopening the circuit breaker roughly every two hours — 1699 discovery pods in 14 days. That churn should subside as the index count falls.

## Notes

- Applying `set-parameters` rewrites the repository format blob; other kopia clients re-read their cached copy within ~15 minutes. kopiur only issues the call when the declared value actually differs.
- The repository is `mode: ReadWrite`, so declaring parameters is permitted.
- kopiur has no default of its own here — an absent value means "leave kopia's current setting alone", so **removing this field later will not restore 24h**; it would have to be set back explicitly.
- The backlog will not clear instantly: epoch 3 (2290 blobs) only becomes compactable once epoch 5 opens.

## Validation

- `kustomize build kubernetes/apps/kopiur-system/kopiur/repository` renders correctly.
- `kubectl apply --dry-run=server` passes admission through the kopiur validating/mutating webhooks.
