### PR TITLE
fix(kopiur): fit B2 index-blob warn threshold to the real steady state

### DIFF
--- a/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository.yaml
@@ -22,11 +22,18 @@ spec:
       name: kopiur-repository-secret
       namespace: kopiur-system
       key: KOPIA_PASSWORD
+  health:
+    # Steady state is ~1800 blobs: ~104 index blobs/hour across ~3 trailing
+    # uncompacted epochs of ~5.5h each. The 1000 default does not fit this
+    # fleet's write rate; connect is 1m39s and the backend probe is stable.
+    indexBlobWarnThreshold: 2500
   parameters:
     epoch:
       # kopia's 24h default let epochs hold ~2600 index blobs at this cluster's
-      # write rate; compaction trails two epochs, so the repo carried ~5k
-      # uncompacted blobs and `repository connect` took over 4 minutes.
+      # write rate, so the repo carried ~5k uncompacted blobs and
+      # `repository connect` took over 4 minutes. Epochs only advance during a
+      # maintenance run, so the 6h quick cadence -- not this floor -- is what
+      # actually bounds epoch length today.
       minDuration: 4h
   scheduleDefaults:
     timezone: America/Los_Angeles


### PR DESCRIPTION
Follow-up to #5623.

## The epoch fix worked

Five days after lowering `epoch.minDuration` to 4h, compaction has recovered:

| | Aug 30 (before) | Sep 4 (now) |
| --- | --- | --- |
| index blobs | 5025, climbing | **1794, bounded** |
| current epoch | 4, stuck 24h+ | **23**, advancing every ~5-6h |
| `repository connect` | 4m13s | **1m39s** |
| `b2-discovery` probe pods | ~350/day | **46/day** |
| circuit breaker opens (48h) | every ~2h | **0** |

Epochs 0–7 and 8–15 have been range-compacted to a single blob each, 16–20 single-epoch compacted. Maintenance has run on schedule every 6h for five days, each run now ~70-110s instead of 3-5 min. `BackendReachable` has been stable `True` since Aug 31.

## Why it settles at ~1800 and not under 1000

`MaybeAdvanceWriteEpoch` has exactly one caller in kopia — `repo/maintenance/maintenance_run.go`. Epochs never advance on ordinary index writes, only inside a maintenance run. So epoch length is bounded by the **6h quick-maintenance cadence**, not by the 4h `minDuration` floor. Observed spans confirm it: 5h8m and 5h44m.

At the measured ~104 index blobs/hour across ~3 trailing uncompacted epochs of ~5.5h, steady state is ~1800.

Clearing the last 800 would require hourly quick maintenance (`0 * * * *`) plus `minDuration: 3h`. That is 6x the maintenance runs and a corresponding increase in B2 API traffic, to satisfy a warning that no longer corresponds to an operational problem. Fitting the threshold to the fleet is the better trade.

## Note on the condition message

kopiur's `TooManyIndexBlobs` message is a static remediation string — it claims "kopia maintenance is not compacting them" and suggests lowering `minDuration` to 6h. Both are stale here: maintenance *is* compacting, and we are already below 6h. Worth ignoring the text if this fires again.

## Also in this PR

Corrected the `minDuration` comment from #5623, which said compaction trails "two epochs". Measured behaviour is ~3.1 trailing epochs (1794 blobs ÷ ~570 per epoch).

## Validation

- `kustomize build kubernetes/apps/kopiur-system/kopiur/repository` renders correctly.
- `kubectl apply --dry-run=server` passes admission through the kopiur webhooks.
