### PR TITLE
fix(cert-manager): gate expiry alert on renewal being overdue

### DIFF
--- a/kubernetes/apps/cert-manager/cert-manager/app/prometheusrule.yaml
+++ b/kubernetes/apps/cert-manager/cert-manager/app/prometheusrule.yaml
@@ -27,6 +27,10 @@ spec:
             avg by (exported_namespace, namespace, name) (
             certmanager_certificate_expiration_timestamp_seconds - time())
               < (21 * 24 * 3600)
+            unless
+            avg by (exported_namespace, namespace, name) (
+            certmanager_certificate_renewal_timestamp_seconds - time())
+              > 0
           for: 15m
           labels:
             severity: warning
@@ -38,7 +42,8 @@ spec:
             runbook_url: https://gitlab.com/uneeq-oss/cert-manager-mixin/-/blob/master/RUNBOOK.md#certmanagercertexpirysoon
             summary:
               "The cert {{ $labels.name }} is {{ $value | humanizeDuration }}
-              from expiry, it should have renewed over a week ago."
+              from expiry and cert-manager has not renewed it past its scheduled
+              renewal time."
         - alert: CertManagerCertNotReady
           expr: |
             max by (name, exported_namespace, namespace, condition) (


### PR DESCRIPTION
Follow-up to #5654, which merged before this commit landed on the branch.

## What changed

`CertManagerCertExpirySoon` fired whenever a cert was within 21 days of expiry, regardless of whether cert-manager was actually due to renew it. The 21-day threshold is now gated on `certmanager_certificate_renewal_timestamp_seconds`:

```promql
avg by (exported_namespace, namespace, name) (
certmanager_certificate_expiration_timestamp_seconds - time())
  < (21 * 24 * 3600)
unless
avg by (exported_namespace, namespace, name) (
certmanager_certificate_renewal_timestamp_seconds - time())
  > 0
```

## Why

The barman-cloud plugin issues `barman-cloud-client` and `barman-cloud-server` with `duration: 2160h` (90d) and `renewBefore: 360h` (15d). cert-manager schedules renewal at 15 days remaining, but the alert triggers at 21 — a guaranteed six-day window of false `warning` alerts every renewal cycle, with both certs `Ready` and cert-manager behaving correctly throughout.

Observed state while the alert was firing:

| cert | renewal due | expiry | fired |
|---|---|---|---|
| `ok8-sh`, `salmon-cafe` | 46.8 d | 76.8 d | no |
| `barman-cloud-*` | **1.9 d** | 16.9 d | yes |

Lowering the threshold or excluding the two certs by name would only move the window, and would break again for the next cert with a short `renewBefore`. Keying off the renewal timestamp tracks the schedule cert-manager is actually following, so the alert means what its name implies: cert-manager should have renewed this and hasn't.

## Reviewer notes

- The summary annotation said the cert "should have renewed over a week ago", which was tied to the old fixed-threshold assumption. It now states renewal is past due, matching what the expression tests.
- `for: 15m` is unchanged. The certs that can now trip this are issued by a local self-signed `Issuer` with no ACME round-trip, so there is no renewal latency to absorb. The LE certs renew at 30 days remaining, outside the 21-day gate, so they cannot flap here.
- Validated against live Prometheus: the new expression returns **0 matches**. Re-run with the renewal gate shifted to treat renewal as overdue, it returns **2 matches** — confirming the gate suppresses healthy certs without silencing real renewal failures.
- `kubectl apply --dry-run=server` accepts the manifest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)